### PR TITLE
Fix stairs light suport for hades_stairs

### DIFF
--- a/morelights_extras/init.lua
+++ b/morelights_extras/init.lua
@@ -179,7 +179,8 @@ minetest.register_node("morelights_extras:stairlight", {
 
         if node.param2 < 4
                 and (node.name:match("^stairs:stair_")
-                  or node.name:match("^mcl_stairs:stair_")) then
+                  or node.name:match("^mcl_stairs:stair_")
+                  or node.name:match("^hades_stairs:stair_")) then
             -- Set `above` to the node actually above the stair, since that's
             -- where the node is placed.
             pointed_thing.above =

--- a/morelights_extras/init.lua
+++ b/morelights_extras/init.lua
@@ -180,7 +180,8 @@ minetest.register_node("morelights_extras:stairlight", {
         if node.param2 < 4
                 and (node.name:match("^stairs:stair_")
                   or node.name:match("^mcl_stairs:stair_")
-                  or node.name:match("^hades_stairs:stair_")) then
+                  or node.name:match("^hades_stairs:stair_")
+                  or (minetest.get_item_group(node.name,"support_stairlight")>0)) then
             -- Set `above` to the node actually above the stair, since that's
             -- where the node is placed.
             pointed_thing.above =


### PR DESCRIPTION
Fix stairs light support for hades_stairs (stairs renamed from stairs to hades_stairs in Hades Revisited)

Stair light placable to on nodes in support_stairlight group. Group can be added to nodes like roofs with identical node_box like stairs.