### PR TITLE
Add screwdriver as optional dependency

### DIFF
--- a/morelights_extras/init.lua
+++ b/morelights_extras/init.lua
@@ -194,7 +194,7 @@ minetest.register_node("morelights_extras:stairlight", {
         return itemstack
     end,
 
-    on_rotate = screwdriver.rotate_simple
+    on_rotate = minetest.global_exists("sscrewdriver") and screwdriver.rotate_simple or nil
 })
 
 --

--- a/morelights_extras/mod.conf
+++ b/morelights_extras/mod.conf
@@ -1,3 +1,4 @@
 name = morelights_extras
 description = Provides miscellaneous lighting nodes.
 depends = morelights
+optional_depends = screwdriver


### PR DESCRIPTION
Fixes error that screwdriver is nil (when loading in random order)